### PR TITLE
Cancelling snipes is now activated with JRuby invocation

### DIFF
--- a/src/com/jbidwatcher/ui/commands/UserActions.java
+++ b/src/com/jbidwatcher/ui/commands/UserActions.java
@@ -479,7 +479,7 @@ public class UserActions implements MessageQueue.Listener {
   }
 
   @MenuCommand(params = 2, action = "Cancel Snipe")
-  private void CancelSnipe(Component src, AuctionEntry ae) {
+  public void DoCancelSnipe(Component src, AuctionEntry ae) {
     int[] rowList = mTabs.getPossibleRows();
     int len = rowList.length;
 


### PR DESCRIPTION
Canceling snipes wasn't available through the JRuby interface. From a cursory reading of the ```JBidwatcherUtilities``` Ruby interface, this change seems to bring snipe cancelling back to life.

I haven't added any regression tests, but cancelling snipes works in the UI, and snipes are gone after restarting the app too (so it appears to work).