### PR TITLE
Detect when the server requests that you update your contact information.

### DIFF
--- a/src/com/jbidwatcher/auction/server/ebay/ebayLoginManager.java
+++ b/src/com/jbidwatcher/auction/server/ebay/ebayLoginManager.java
@@ -261,6 +261,13 @@ public class ebayLoginManager implements LoginManager {
         }
       }
 
+      boolean updateContactInfo = false;
+      for(String page : resultPages) {
+          if(page.indexOf("UpdateContactInfo") != -1) {
+        	  updateContactInfo = true;
+          }
+        }
+      
       if (adult) {
         if (getAdultRedirector(uc_signin, cj)) {
           if (mNotifySwing) MQFactory.getConcrete("Swing").enqueue("VALID_LOGIN");
@@ -274,7 +281,14 @@ public class ebayLoginManager implements LoginManager {
         if(fixYourPassword || doc.getTitle().equals("Reset your password")) {
           JConfig.log().logMessage("eBay is requesting that you change your password.");
           MQFactory.getConcrete("login").enqueue("FAILED You must change your password on eBay.");
-        } else if (doc.getTitle().contains("Secret Question")) {
+        } 
+		else if (updateContactInfo) {
+			String notification = "eBay is requesting that you update your contact information.";
+			JConfig.log().logMessage(notification);
+			MQFactory.getConcrete("login").enqueue("SUCCESSFUL " + notification);
+			if (mNotifySwing) MQFactory.getConcrete("Swing").enqueue("VALID_LOGIN");
+		}
+        else if (doc.getTitle().contains("Secret Question")) {
           String notification = "eBay is requesting that you provide security questions for account recovery.";
           JConfig.log().logMessage(notification);
           MQFactory.getConcrete("login").enqueue("SUCCESSFUL " + notification);


### PR DESCRIPTION
Previously, when a login request forwarded the user to the "UpdateContactInfo" page, this would be detected as a potential failure. This pull request adds some basic logic to detect this situation, marking it as a successful login instead. Hopefully I've handled this in the right way!

This is to deal with the following failure (from the error log):

>Getting the sign in cookie for ebay.co.uk
Parsing URL https://signin.ebay.co.uk/ws2/eBayISAPI.dll?SignIn
Potential quote error!
Parsing URL https://signin.ebay.co.uk/ws/eBayISAPI.dll?co_partnerId=2&siteid=3&UsingSSL=1
Redirecting from: https://signin.ebay.co.uk/ws/eBayISAPI.dll?co_partnerId=2&siteid=3&UsingSSL=1
Redirecting to: https://reg.ebay.co.uk/reg/UpdateContactInfo?_uci=2&flow=SIGN_IN&ru=http%3A%2F%2Fwww.ebay.co.uk
Parsing URL https://reg.ebay.co.uk/reg/UpdateContactInfo?_uci=2&flow=SIGN_IN&ru=http%3A%2F%2Fwww.ebay.co.uk
...
File contents logged with message: Security checks out, but no My eBay form link on final page...
...
Done getting the sign in cookie for ebay.co.uk