### PR TITLE
Avoid server-side redirections for completed auctions

### DIFF
--- a/resources/jbidwatcher.properties
+++ b/resources/jbidwatcher.properties
@@ -3,7 +3,7 @@ ebayServer.protocol=http://
 ebayServer.file=/ws/eBayISAPI.dll
 ebayServer.V3file=/ws/eBayISAPI.dll
 ebayServer.viewCmd=ViewItem&
-ebayServer.viewCGI=item=
+ebayServer.viewCGI=nordt=true&item=
 ebayServer.searchURL2=&srchdesc=y&category0=&ebaytag1=ebayctry&ebaytag1code=0&SortProperty=MetaEndSort&SortOrder=%5Ba%5D&st=0&maxRecordsPerPage=100
 ebayServer.searchURLNoDesc=&srchdesc=n&category0=&ebaytag1=ebayctry&ebaytag1code=0&SortProperty=MetaEndSort&SortOrder=%5Ba%5D&st=0&maxRecordsPerPage=100
 ebayServer.bidCmd=MfcISAPICommand=MakeBid


### PR DESCRIPTION
The eBay website now redirects auction listings for completed items away to unsold similar items. This change modifies the URL parameters to avoid these server-side redirections.